### PR TITLE
Update for HA2025.1 update -  sensor.py

### DIFF
--- a/edl21/sensor.py
+++ b/edl21/sensor.py
@@ -20,12 +20,11 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     CONF_NAME,
     DEGREE,
-    ELECTRIC_CURRENT_AMPERE,
-    ELECTRIC_POTENTIAL_VOLT,
-    ENERGY_KILO_WATT_HOUR,
-    ENERGY_WATT_HOUR,
-    FREQUENCY_HERTZ,
-    POWER_WATT,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
+    UnitOfPower,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -261,13 +260,13 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
 SENSORS = {desc.key: desc for desc in SENSOR_TYPES}
 
 SENSOR_UNIT_MAPPING = {
-    "Wh": ENERGY_WATT_HOUR,
-    "kWh": ENERGY_KILO_WATT_HOUR,
-    "W": POWER_WATT,
-    "A": ELECTRIC_CURRENT_AMPERE,
-    "V": ELECTRIC_POTENTIAL_VOLT,
+    "Wh": UnitOfEnergy.WATT_HOUR,
+    "kWh": UnitOfEnergy.KILO_WATT_HOUR,
+    "W": UnitOfPower.WATT,
+    "A": UnitOfElectricCurrent.AMPERE,
+    "V": UnitOfElectricPotential.VOLT,
     "°": DEGREE,
-    "Hz": FREQUENCY_HERTZ,
+    "Hz": UnitOfFrequency.HERTZ,
 }
 
 


### PR DESCRIPTION
This changes remove the Warnings in Homeassistant and respect the new changes coming with HA 2025.1 version. 
 
HA config parameters are updated.

In my Tests everything works fine.